### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -12,8 +12,8 @@
     ],
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
-  "nxCloudUrl": "https://snapshot.nx.app",
-  "nxCloudId": "6855e11c79874772c8ab27ba",
+  "nxCloudUrl": "http://localhost:4202",
+  "nxCloudId": "68431e8d677bd0154b2c66de",
   "plugins": [
     {
       "plugin": "@nx/js/typescript",

--- a/nx.json
+++ b/nx.json
@@ -12,8 +12,8 @@
     ],
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
-  "nxCloudUrl": "http://localhost:4202",
-  "nxCloudId": "68431e8d677bd0154b2c66de",
+  "nxCloudUrl": "https://snapshot.nx.app",
+  "nxCloudId": "68c0479066287c4fce27ef40",
   "plugins": [
     {
       "plugin": "@nx/js/typescript",


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
http://localhost:4202/orgs/67dc650f0aa8e666c0230e9c/workspaces/68431e8d677bd0154b2c66de

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.